### PR TITLE
chore(ci): guard deploy job on main only when enabled and secrets present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
     name: Deploy to VPS (rsync over SSH)
     needs: build-and-test
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' }}
+    # Run only on main, when deployment is enabled AND all secrets are present
+    if: ${{ github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' && secrets.DEPLOY_SSH_KEY != '' && secrets.DEPLOY_USER != '' && secrets.DEPLOY_HOST != '' && secrets.DEPLOY_PATH != '' }}
     env:
       DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
       DEPLOY_USER: ${{ secrets.DEPLOY_USER }}


### PR DESCRIPTION
Deploy job failed with 'Could not resolve hostname' because DEPLOY_HOST was empty/not configured in PR merges.\n\nFix:\n- Add guard to deploy job: runs only on main AND when repository variable DEPLOY_ENABLED=='true' AND all required secrets are set (DEPLOY_SSH_KEY, DEPLOY_USER, DEPLOY_HOST, DEPLOY_PATH).\n- This prevents failing deploys on PRs and branches while keeping automatic deployment for protected main when enabled.\n\nAcceptance criteria:\n- In PRs: deploy job is skipped.\n- On merge to main without secrets or DEPLOY_ENABLED!=true: deploy is skipped.\n- On merge to main with secrets and DEPLOY_ENABLED=true: deploy runs successfully.