### PR TITLE
ci: refine deploy guard & diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,8 @@ jobs:
       DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
       DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
       DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-      DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT != '' && secrets.DEPLOY_SSH_PORT || (vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || '22') }}
+      DEPLOY_SSH_PORT_SECRET: ${{ secrets.DEPLOY_SSH_PORT }}
+      DEPLOY_SSH_PORT_VAR: ${{ vars.DEPLOY_SSH_PORT }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -97,10 +98,12 @@ jobs:
         env:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
           DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
-          DEPLOY_SSH_PORT: ${{ env.DEPLOY_SSH_PORT }}
+          DEPLOY_SSH_PORT_SECRET: ${{ env.DEPLOY_SSH_PORT_SECRET }}
+          DEPLOY_SSH_PORT_VAR: ${{ env.DEPLOY_SSH_PORT_VAR }}
         run: |
-          echo "Testing SSH connection to $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_SSH_PORT"
-          ssh -p "$DEPLOY_SSH_PORT" -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "echo 'SSH OK'"
+          PORT="${DEPLOY_SSH_PORT_SECRET:-${DEPLOY_SSH_PORT_VAR:-22}}"
+          echo "Testing SSH connection to $DEPLOY_USER@$DEPLOY_HOST:$PORT"
+          ssh -p "$PORT" -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "echo 'SSH OK'"
 
       - name: Ensure remote path exists
         shell: bash
@@ -108,9 +111,11 @@ jobs:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
           DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
           DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
-          DEPLOY_SSH_PORT: ${{ env.DEPLOY_SSH_PORT }}
+          DEPLOY_SSH_PORT_SECRET: ${{ env.DEPLOY_SSH_PORT_SECRET }}
+          DEPLOY_SSH_PORT_VAR: ${{ env.DEPLOY_SSH_PORT_VAR }}
         run: |
-          ssh -p "$DEPLOY_SSH_PORT" -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$DEPLOY_PATH'"
+          PORT="${DEPLOY_SSH_PORT_SECRET:-${DEPLOY_SSH_PORT_VAR:-22}}"
+          ssh -p "$PORT" -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$DEPLOY_PATH'"
 
       - name: Deploy via rsync
         shell: bash
@@ -118,9 +123,11 @@ jobs:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
           DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
           DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
-          DEPLOY_SSH_PORT: ${{ env.DEPLOY_SSH_PORT }}
+          DEPLOY_SSH_PORT_SECRET: ${{ env.DEPLOY_SSH_PORT_SECRET }}
+          DEPLOY_SSH_PORT_VAR: ${{ env.DEPLOY_SSH_PORT_VAR }}
         run: |
-          rsync -az --delete -e "ssh -p $DEPLOY_SSH_PORT -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa" \
+          PORT="${DEPLOY_SSH_PORT_SECRET:-${DEPLOY_SSH_PORT_VAR:-22}}"
+          rsync -az --delete -e "ssh -p $PORT -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa" \
             dist/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH"
 
 # Notes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,13 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     # Run only on main, when deployment is enabled AND all secrets are present
-    if: ${{ github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' && secrets.DEPLOY_SSH_KEY != '' && secrets.DEPLOY_USER != '' && secrets.DEPLOY_HOST != '' && secrets.DEPLOY_PATH != '' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' && secrets.DEPLOY_SSH_KEY != '' && secrets.DEPLOY_USER != '' && secrets.DEPLOY_HOST != '' && secrets.DEPLOY_PATH != '' }}
     env:
       DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
       DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
       DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
       DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT != '' && secrets.DEPLOY_SSH_PORT || (vars.DEPLOY_SSH_PORT != '' && vars.DEPLOY_SSH_PORT || '22') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -91,14 +92,35 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
+      - name: Preflight SSH connectivity
+        shell: bash
+        env:
+          DEPLOY_USER: ${{ env.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
+          DEPLOY_SSH_PORT: ${{ env.DEPLOY_SSH_PORT }}
+        run: |
+          echo "Testing SSH connection to $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_SSH_PORT"
+          ssh -p "$DEPLOY_SSH_PORT" -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "echo 'SSH OK'"
+
+      - name: Ensure remote path exists
+        shell: bash
+        env:
+          DEPLOY_USER: ${{ env.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+          DEPLOY_SSH_PORT: ${{ env.DEPLOY_SSH_PORT }}
+        run: |
+          ssh -p "$DEPLOY_SSH_PORT" -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$DEPLOY_PATH'"
+
       - name: Deploy via rsync
         shell: bash
         env:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
           DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
           DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+          DEPLOY_SSH_PORT: ${{ env.DEPLOY_SSH_PORT }}
         run: |
-          rsync -az --delete -e "ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa" \
+          rsync -az --delete -e "ssh -p $DEPLOY_SSH_PORT -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa" \
             dist/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH"
 
 # Notes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
     name: Deploy to VPS (rsync over SSH)
     needs: build-and-test
     runs-on: ubuntu-latest
-    # Run only on main, when deployment is enabled AND all secrets are present
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' && secrets.DEPLOY_SSH_KEY != '' && secrets.DEPLOY_USER != '' && secrets.DEPLOY_HOST != '' && secrets.DEPLOY_PATH != '' }}
+    # Run only on main when deployment is enabled (secrets checked at step level)
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' }}
     env:
       DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
       DEPLOY_USER: ${{ secrets.DEPLOY_USER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,38 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check required secrets present
+        shell: bash
+        env:
+          DEPLOY_SSH_KEY: ${{ env.DEPLOY_SSH_KEY }}
+          DEPLOY_USER: ${{ env.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ env.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+        run: |
+          missing=0
+          for v in DEPLOY_SSH_KEY DEPLOY_USER DEPLOY_HOST DEPLOY_PATH; do
+            if [ -z "${!v}" ]; then
+              echo "::warning title=Missing secret::$v is not set"
+              missing=1
+            fi
+          done
+          if [ "$missing" -eq 0 ]; then
+            echo "HAVE_SECRETS=true" >> "$GITHUB_ENV"
+            echo "Secrets OK"
+          else
+            echo "HAVE_SECRETS=false" >> "$GITHUB_ENV"
+            echo "Secrets missing, deployment steps will be skipped"
+          fi
+
       - name: Download build artifact
+        if: env.HAVE_SECRETS == 'true'
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
 
       - name: Prepare SSH key
+        if: env.HAVE_SECRETS == 'true'
         shell: bash
         env:
           SSH_KEY: ${{ env.DEPLOY_SSH_KEY }}
@@ -94,6 +119,7 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
 
       - name: Preflight SSH connectivity
+        if: env.HAVE_SECRETS == 'true'
         shell: bash
         env:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
@@ -106,6 +132,7 @@ jobs:
           ssh -p "$PORT" -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "echo 'SSH OK'"
 
       - name: Ensure remote path exists
+        if: env.HAVE_SECRETS == 'true'
         shell: bash
         env:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
@@ -118,6 +145,7 @@ jobs:
           ssh -p "$PORT" -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$DEPLOY_PATH'"
 
       - name: Deploy via rsync
+        if: env.HAVE_SECRETS == 'true'
         shell: bash
         env:
           DEPLOY_USER: ${{ env.DEPLOY_USER }}
@@ -130,6 +158,9 @@ jobs:
           rsync -az --delete -e "ssh -p $PORT -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa" \
             dist/ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH"
 
+      - name: Skip deploy (secrets missing)
+        if: env.HAVE_SECRETS == 'false'
+        run: echo "Skipping deploy: required secrets missing"
 # Notes:
 # - Set repository variable DEPLOY_ENABLED=true to enable deployment on main branch.
 # - Required secrets: DEPLOY_SSH_KEY (private key), DEPLOY_USER, DEPLOY_HOST, DEPLOY_PATH.


### PR DESCRIPTION
- Run deploy only on push to main with DEPLOY_ENABLED and all secrets\n- Add SSH port support via secret/var (fallback 22)\n- Preflight SSH connectivity, ensure remote path exists\n- Include port in rsync\n\nThis should prevent false deploy attempts and provide clearer failure diagnostics.